### PR TITLE
Fix start:prod command to use correct file extension

### DIFF
--- a/apps/media-service/package.json
+++ b/apps/media-service/package.json
@@ -11,7 +11,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node dist/main.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
- Change from 'node dist/main' to 'node dist/main.js'
- The build process creates main.js, not main