### PR TITLE
Add @types/express to dependencies for TypeScript compilation

### DIFF
--- a/apps/media-service/package.json
+++ b/apps/media-service/package.json
@@ -44,14 +44,14 @@
     "rxjs": "^7.8.1",
     "sharp": "^0.33.0",
     "uuid": "^9.0.1",
-    "@nestjs/cli": "^10.4.9"
+    "@nestjs/cli": "^10.4.9",
+    "@types/express": "^4.17.17"
   },
   "devDependencies": {
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
     "@types/compression": "^1.7.5",
     "@types/cors": "^2.8.17",
-    "@types/express": "^4.17.17",
     "@types/fluent-ffmpeg": "^2.1.24",
     "@types/jest": "^29.5.2",
     "@types/multer": "^1.4.11",


### PR DESCRIPTION
- Move @types/express from devDependencies to dependencies
- This fixes the 'Cannot find namespace Express' TypeScript errors
- Required for Render deployment build process