### PR TITLE
Add @types/multer to dependencies for TypeScript compilation

### DIFF
--- a/apps/media-service/package.json
+++ b/apps/media-service/package.json
@@ -45,7 +45,8 @@
     "sharp": "^0.33.0",
     "uuid": "^9.0.1",
     "@nestjs/cli": "^10.4.9",
-    "@types/express": "^4.17.17"
+    "@types/express": "^4.17.17",
+    "@types/multer": "^1.4.11"
   },
   "devDependencies": {
     "@nestjs/schematics": "^10.0.0",
@@ -54,7 +55,6 @@
     "@types/cors": "^2.8.17",
     "@types/fluent-ffmpeg": "^2.1.24",
     "@types/jest": "^29.5.2",
-    "@types/multer": "^1.4.11",
     "@types/node": "^20.3.1",
     "@types/supertest": "^2.0.12",
     "@types/uuid": "^9.0.7",


### PR DESCRIPTION
- Move @types/multer from devDependencies to dependencies
- This fixes the 'Express.Multer.File' TypeScript errors
- Required for Render deployment build process