### PR TITLE
Hardcode backend URL as fallback

### DIFF
--- a/apps/web/src/utils/config.ts
+++ b/apps/web/src/utils/config.ts
@@ -9,9 +9,9 @@ const config = {
   // Backend URLs
   backend: {
     // For server-side requests (SSR, API routes)
-    server: process.env.BACKEND_URL_SERVER || process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:5001",
+    server: process.env.BACKEND_URL_SERVER || "https://bitescout-69t9.onrender.com",
     // For client-side requests (browser)
-    client: process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:5001",
+    client: process.env.NEXT_PUBLIC_BACKEND_URL || "https://bitescout-69t9.onrender.com",
   },
   
   // Media Service URLs


### PR DESCRIPTION
- Use production backend URL as fallback instead of localhost
- This ensures frontend always uses correct backend URL
- Fixes CORS errors from cached localhost requests